### PR TITLE
Remove custom commit message for `readmeContent`

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -28,7 +28,6 @@ status-website:
       href: https://github.com/$OWNER/$REPO
       
 commitMessages:
-  readmeContent: ":pencil: Update summary in README [skip ci]"
   summaryJson: ":card_file_box: Update status summary [skip ci]"
   statusChange: "$EMOJI $SITE_NAME is $STATUS ($RESPONSE_CODE in $RESPONSE_TIME ms) [skip ci]"
   graphsUpdate: ":bento: Update graphs [skip ci]"


### PR DESCRIPTION
You don't need this because CI isn't configured in readme